### PR TITLE
List all nurseries on index page by default (WIP, do not merge yet)

### DIFF
--- a/app/controllers/nurseries_controller.rb
+++ b/app/controllers/nurseries_controller.rb
@@ -7,7 +7,7 @@ class NurseriesController < ApplicationController
                      only: [:index, :results, :show]
 
   def index
-    @nurseries = Nursery.where(district: params[:district])
+    @nurseries = Nursery.all
     @districts = Nursery.uniq.pluck(:district)
   end
 

--- a/app/views/nurseries/index.html.erb
+++ b/app/views/nurseries/index.html.erb
@@ -9,13 +9,13 @@
       <% @districts.each do |district| %>
         <div class="checkbox district-filter">
           <label>
-            <input type="checkbox" name="district[]" value="<%= district %>"><%= district %></input>
+            <input type="checkbox" name="district[]" value="<%= district %>" checked><%= district %></input>
           </label>
         </div>
       <% end %>
       <div class="checkbox district-filter">
         <label>
-          <input type="checkbox" name="all">Alle</input>
+          <input type="checkbox" name="all" checked>Alle</input>
         </label>
       </div>
     <% end  %>


### PR DESCRIPTION
**This is Work in Progress, please do not merge yet!** Feedback is very welcome, though.

The index page for nurseries has a group of checkboxes at the top of the page to filter the nurseries displayed by district. All checkboxes were unchecked by default and an empty list was displayed to the user.

Change the default so that all checkboxes are initially checked an thus all nurseries are listed. The user can than narrow down the list by unchecking certain districts.

Note: We can change `@nurseries` in the index action to `Nursery.all` because the JavaScript form for filtering is send to the `results` action, not the `index` action.

- [x] Invert default for checkboxes from unchecked to checked, list all nurseries
- [ ] Fix bug where checkbox labeled "Alle" (all) will stay checked even after all other checkboxes were manually unchecked (or stay uncheck if all others were manually checked).
- [ ] Add tests (a little bit tricky to set up, because JavaScript is involved)